### PR TITLE
[Test #57] Jacoco 테스트 커버리지 플러그인 & 요청값 validator 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.3'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'com.example'
@@ -39,4 +40,35 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jacocoTestReport {
+	// 'test' Task가 성공적으로 실행된 후에만 리포트 생성
+	dependsOn test
+
+	reports {
+		html.required = true
+		xml.required = false
+		csv.required = false
+	}
+
+	// 커버리지 측정에서 제외할 클래스 설정
+	// DTO, Config, Enum, Exception 클래스 제외, 순수 비즈니스 로직의 커버리지를 측정
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: [
+					"**/*Application*",
+					"**/config/**",
+					"**/dto/**",
+					"**/common/**",
+					"**/*Category",
+					"**/advice/**",
+					"**/log/**"
+			])
+		}))
+	}
+}
+
+test {
+	finalizedBy jacocoTestReport
 }

--- a/src/test/java/com/example/suki/CoffeeMaxOneValidatorTest.java
+++ b/src/test/java/com/example/suki/CoffeeMaxOneValidatorTest.java
@@ -1,0 +1,48 @@
+package com.example.suki;
+
+import com.example.suki.api.validation.CoffeeMaxOneValidator;
+import com.example.suki.domain.item.ConsumableItemCategory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CoffeeMaxOneValidatorTest {
+    private CoffeeMaxOneValidator validator = new CoffeeMaxOneValidator();
+
+    @Test
+    void 아이템_목록에_커피가_없으면_유효하다() {
+        Map<ConsumableItemCategory, Integer> itemMap = Map.of(ConsumableItemCategory.CHOCOLATE_MILK, 1, ConsumableItemCategory.PUFFED_RICE, 2);
+
+        boolean isValid = validator.isValid(itemMap, null);
+
+        assertTrue(isValid);
+    }
+
+    @Test
+    void 아이템_목록에_커피가_하나_있으면_유효하다() {
+        Map<ConsumableItemCategory, Integer> itemMap1 = Map.of(ConsumableItemCategory.COFFEE, 1);
+        Map<ConsumableItemCategory, Integer> itemMap2 = Map.of(ConsumableItemCategory.COFFEE_X2, 1);
+
+        boolean isValid1 = validator.isValid(itemMap1, null);
+        boolean isValid2 = validator.isValid(itemMap2, null);
+
+        assertTrue(isValid1);
+        assertTrue(isValid2);
+    }
+
+    @Test
+    void 아이템_목록에_커피가_2개_이상_있으면_유효하지_않다() {
+        Map<ConsumableItemCategory, Integer> itemMap1 = Map.of(ConsumableItemCategory.COFFEE, 2);
+        Map<ConsumableItemCategory, Integer> itemMap2 = Map.of(ConsumableItemCategory.COFFEE_X2, 2);
+
+        boolean isValid1 = validator.isValid(itemMap1, null);
+        boolean isValid2 = validator.isValid(itemMap2, null);
+
+        assertFalse(isValid1);
+        assertFalse(isValid2);
+    }
+
+}

--- a/src/test/java/com/example/suki/CoffeeMutuallyExclusiveValidatorTest.java
+++ b/src/test/java/com/example/suki/CoffeeMutuallyExclusiveValidatorTest.java
@@ -1,0 +1,32 @@
+package com.example.suki;
+
+import com.example.suki.api.validation.CoffeeMutuallyExclusiveValidator;
+import com.example.suki.domain.item.ConsumableItemCategory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CoffeeMutuallyExclusiveValidatorTest {
+    private CoffeeMutuallyExclusiveValidator validator = new CoffeeMutuallyExclusiveValidator();
+
+    @Test
+    void 아이템_목록에_커피가_배타적으로_존재하면_유효하다() {
+        Map<ConsumableItemCategory, Integer> itemMap = Map.of(ConsumableItemCategory.COFFEE, 1);
+
+        boolean isValid = validator.isValid(itemMap, null);
+
+        assertTrue(isValid);
+    }
+
+    @Test
+    void 아이템_목록에_커피가_동시에_존재하면_유효하지_않다() {
+        Map<ConsumableItemCategory, Integer> itemMap = Map.of(ConsumableItemCategory.COFFEE, 1, ConsumableItemCategory.COFFEE_X2, 1);
+
+        boolean isValid = validator.isValid(itemMap, null);
+
+        assertFalse(isValid);
+    }
+}


### PR DESCRIPTION
## 🚀 개발 내용
- Jacoco 플러그인 추가
- Jacoco 레포트 설정
- 소비성 아이템 커피 관련 validator 테스트 추가

<img width="1107" height="401" alt="image" src="https://github.com/user-attachments/assets/7e2df233-1f63-49f6-bbd7-3a079aa590f4" />

## 📌 이슈 번호
close #57 