### PR TITLE
[Feature #59] 동일 입력의 API 중복 요청 방지

### DIFF
--- a/src/main/java/com/example/suki/api/controller/SimulationController.java
+++ b/src/main/java/com/example/suki/api/controller/SimulationController.java
@@ -1,6 +1,7 @@
 package com.example.suki.api.controller;
 
 import com.example.suki.api.dto.*;
+import com.example.suki.api.lock.PreventDuplicateRequest;
 import com.example.suki.application.SimulationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,18 +28,21 @@ public class SimulationController {
         throw new IllegalArgumentException("error");
     }
 
+    @PreventDuplicateRequest
     @Operation(summary = "체력 n 달성 조합 반환")
     @PostMapping("/reach")
     public ApiResponse<SimulationResponse> simulateReach(@Valid @RequestBody SimulationRequest request) {
         return ApiResponse.ok(simulationService.simulateReach(request));
     }
 
+    @PreventDuplicateRequest
     @Operation(summary = "체력 n으로 마무리 조합 반환")
     @PostMapping("/finish-at")
     public ApiResponse<SimulationResponse> simulateFinishAt(@Valid @RequestBody SimulationRequest request) {
         return ApiResponse.ok(simulationService.simulateFinishAt(request));
     }
 
+    @PreventDuplicateRequest
     @Operation(summary = "체력 n1 ~ n2로 마무리 조합 반환")
     @PostMapping("/finish-within")
     public ApiResponse<SimulationRangeResponse> simulateFinishWithin(@Valid @RequestBody SimulationRangeRequest request) {

--- a/src/main/java/com/example/suki/api/exception/ErrorCode.java
+++ b/src/main/java/com/example/suki/api/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // Common
     VALIDATION_FAILED("C001", HttpStatus.BAD_REQUEST, "요청 값이 올바르지 않습니다."),
+    DUPLICATE_REQUEST("C002", HttpStatus.TOO_MANY_REQUESTS, "짧은 시간 내에 동일한 요청을 보낼 수 없습니다."),
 
     // User
     PLACE_ALREADY_ACTIVATED("U001", HttpStatus.CONFLICT, "이미 활성화된 장소입니다."),

--- a/src/main/java/com/example/suki/api/lock/DuplicatedRequestAspect.java
+++ b/src/main/java/com/example/suki/api/lock/DuplicatedRequestAspect.java
@@ -13,10 +13,7 @@ import org.springframework.util.DigestUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 @Aspect
 @Component
@@ -66,18 +63,12 @@ public class DuplicatedRequestAspect {
     }
 
     private String getClientIp(HttpServletRequest request) {
-        String ip = request.getHeader("X-Forwarded-For");
+        String ip = request.getHeader("Forwarded");
         if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("Proxy-Client-IP");
+            ip = request.getHeader("X-Forwarded-For");
         }
         if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("WL-Proxy-Client-IP");
-        }
-        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("HTTP_CLIENT_IP");
-        }
-        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+            ip = request.getHeader("X-Real-IP");
         }
         if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
             ip = request.getRemoteAddr();

--- a/src/main/java/com/example/suki/api/lock/DuplicatedRequestAspect.java
+++ b/src/main/java/com/example/suki/api/lock/DuplicatedRequestAspect.java
@@ -1,0 +1,65 @@
+package com.example.suki.api.lock;
+
+import com.example.suki.api.exception.BusinessException;
+import com.example.suki.api.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.util.DigestUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DuplicatedRequestAspect {
+    private final ConcurrentHashMap<String, Lock> lockMap = new ConcurrentHashMap<>();
+
+    @Around("@annotation(com.example.suki.api.lock.PreventDuplicateRequest)")
+    public Object preventDuplicateRequest(ProceedingJoinPoint joinPoint) throws Throwable {
+        String requestKey = generateRequestKey(joinPoint);
+
+        Lock lock = lockMap.computeIfAbsent(requestKey, k -> new ReentrantLock());
+
+        boolean acquired = lock.tryLock();
+
+        if (!acquired) {
+            log.warn("Duplicate request detected: {}", requestKey);
+            throw new BusinessException(ErrorCode.DUPLICATE_REQUEST);
+        }
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            lock.unlock();
+            lockMap.remove(requestKey);
+        }
+    }
+
+    private String generateRequestKey(ProceedingJoinPoint joinPoint) {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        String userIdentifier = request.getSession().getId(); // 세션 ID로 사용자 식별
+        log.debug("User: {}", userIdentifier);
+
+        StringBuilder payloadBuilder = new StringBuilder();
+        for (Object arg : joinPoint.getArgs()) {
+            if (arg != null) {
+                payloadBuilder.append(arg);
+            }
+        }
+
+        // MD5 해시 -> 최종 키 생성 (사용자 ID + 요청 URL + 요청 본문 해시)
+        String combined = userIdentifier + request.getRequestURI() + payloadBuilder;
+        return DigestUtils.md5DigestAsHex(combined.getBytes());
+    }
+}

--- a/src/main/java/com/example/suki/api/lock/PreventDuplicateRequest.java
+++ b/src/main/java/com/example/suki/api/lock/PreventDuplicateRequest.java
@@ -1,0 +1,11 @@
+package com.example.suki.api.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PreventDuplicateRequest {
+}

--- a/src/main/resources/static/js/simulations-common.js
+++ b/src/main/resources/static/js/simulations-common.js
@@ -222,6 +222,11 @@ const actionLabel = v => ACTION_LABELS[v] ?? v;
                 const data = parsed && typeof parsed === 'object' ? (parsed.data ?? parsed) : parsed ?? text;
 
                 document.dispatchEvent(new CustomEvent('sim:response', {detail: {ok: res.ok, data, endpoint}}));
+                if (res.status === 429) {
+                    const msg = (typeof data === 'object' && (data.message || data.detail)) || '짧은 시간 내에 동일한 요청을 보낼 수 없습니다.';
+                    alert(msg);
+                    return;
+                }
                 if (!res.ok || typeof data !== 'object') throw new Error(typeof data === 'string' ? data : '요청 실패');
 
                 renderResult(data, document);


### PR DESCRIPTION
### **User description**
## 🚀 개발 내용
- 서버 측 방어: AOP로 사용자 IP or Session ID 검사하여 중복 방지
  - 사용자 식별자 + API Url + Request Body 해싱
  - ConcurrentHashMap 통해 원자성 보장
- 클라이언트 측 방어: 응답 오기 전까지 버튼 비활성화
  - TOO_MANY_REQUEST 받을 시 팝업 알림

## 📌 이슈 번호
close #59


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- 중복 API 요청 방지 기능 구현
  - AOP를 사용하여 서버 측에서 중복 요청을 방지
  - `ConcurrentHashMap`을 사용하여 요청 잠금

- 클라이언트 측에서 429 상태 코드 처리 및 알림 표시


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[/"API 요청"/] --> B{{"중복 요청 확인 (AOP)"/}}
  B -- "중복" --> C[/"429 에러 반환"/]
  B -- "정상" --> D[/"API 처리"/]
  D --> E[/"응답 반환"/]
  E --> F{{"클라이언트 응답 처리"/}}
  F -- "429 에러" --> G[/"알림 표시"/]
  F -- "정상 응답" --> H[/"결과 렌더링"/]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SimulationController.java</strong><dd><code>API 엔드포인트에 중복 요청 방지 어노테이션 적용</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/example/suki/api/controller/SimulationController.java

- `PreventDuplicateRequest` 어노테이션을 사용하여 API 엔드포인트에 중복 요청 방지 기능 적용


</details>


  </td>
  <td><a href="https://github.com/isExample/Suki-Helper/pull/60/files#diff-e459d863dd0fdf1733fdda5b75ef80dea71e4203f48c5fdae793c5188187ac31">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ErrorCode.java</strong><dd><code>중복 요청 에러 코드 추가 (429 상태 코드)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/example/suki/api/exception/ErrorCode.java

- `DUPLICATE_REQUEST` 에러 코드 추가 (HTTP 429 상태 코드 사용)


</details>


  </td>
  <td><a href="https://github.com/isExample/Suki-Helper/pull/60/files#diff-302e203bbd25f254bf15806d62d117f74ba9f08c9f5aa3b7ae3e0690787873d8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DuplicatedRequestAspect.java</strong><dd><code>AOP 기반 중복 요청 방지 Aspect 구현</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/example/suki/api/lock/DuplicatedRequestAspect.java

<ul><li>AOP를 사용하여 중복 요청을 방지하는 Aspect 구현<br> <li> 요청 식별 키 생성 로직 구현 (세션 ID, 요청 URL, 요청 본문 기반)<br> <li> <code>ConcurrentHashMap</code>을 사용하여 요청 잠금 관리</ul>


</details>


  </td>
  <td><a href="https://github.com/isExample/Suki-Helper/pull/60/files#diff-0399d9b8e69e4060b1d5a52a979d98280b3a8b549c10bfaaf070cc24cfa3568e">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PreventDuplicateRequest.java</strong><dd><code>중복 요청 방지 어노테이션 정의</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/example/suki/api/lock/PreventDuplicateRequest.java

- 중복 요청 방지 어노테이션 정의


</details>


  </td>
  <td><a href="https://github.com/isExample/Suki-Helper/pull/60/files#diff-c22e276f6fdd20b5b37cd4af6e4f6df1c3fc61608edabf0e28561ba0291af476">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>simulations-common.js</strong><dd><code>클라이언트 측 중복 요청 처리 및 알림 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/static/js/simulations-common.js

- HTTP 429 상태 코드 처리 로직 추가
- 중복 요청 시 사용자에게 알림 메시지 표시


</details>


  </td>
  <td><a href="https://github.com/isExample/Suki-Helper/pull/60/files#diff-8f705abc0c676acbd500239e2790ae118d27905ac55bfab7629deabd51c6c7cb">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

